### PR TITLE
Fix Zombo spawn egg not having a translation key.

### DIFF
--- a/src/main/resources/assets/examplemod/lang/en_us.json
+++ b/src/main/resources/assets/examplemod/lang/en_us.json
@@ -16,6 +16,7 @@
   "item.examplemod.lattechicken_egg": "Latte Chicken Egg",
   "item.examplemod.evilrabbit_egg": "Evil Rabbit Spawn Egg",
   "item.examplemod.grumboboy_egg": "Grumbo Boy Egg",
+  "item.examplemod.zombo_egg": "Zombo Egg",
   "item.examplemod.custom_helm": "Custom Helm",
   "item.examplemod.custom_chest": "Custom Chest",
   "item.examplemod.custom_legs": "Custom Legs",


### PR DESCRIPTION
I noticed the Zombo spawn egg didn't have a translatable name during testing.